### PR TITLE
Make free build + repr(C) fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ libc = "*"
 
 [dev-dependencies]
 glob = "*"
+
+[build-dependencies]
+gcc = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,28 +1,20 @@
 #![allow(unused_must_use)]
 #![allow(dead_code)]
 
-use std::process::Command;
-use std::path::Path;
-use std::env;
-use std::fs;
+extern crate gcc;
+
+const LIBHOEDOWN_SRC: &'static [&'static str] = &[
+  "libhoedown/src/autolink.c",
+  "libhoedown/src/buffer.c",
+  "libhoedown/src/document.c",
+  "libhoedown/src/escape.c",
+  "libhoedown/src/html.c",
+  "libhoedown/src/html_blocks.c",
+  "libhoedown/src/html_smartypants.c",
+  "libhoedown/src/stack.c",
+  "libhoedown/src/version.c",
+];
 
 fn main() {
-  let manifest = env::var("CARGO_MANIFEST_DIR").unwrap();
-  let root_dir = Path::new(&manifest);
-
-  let out = env::var("OUT_DIR").unwrap();
-  let out_dir = Path::new(&out);
-
-  Command::new("make")
-    .arg("-C").arg("libhoedown")
-    .arg("libhoedown.a")
-    .status().unwrap();
-
-  let lib_path = root_dir.join("libhoedown/libhoedown.a");
-  let target = out_dir.join("libhoedown.a");
-
-  fs::rename(&lib_path, &target).unwrap();
-
-  println!("cargo:rustc-flags=-L native={} -l static=hoedown", out_dir.to_str().unwrap());
+  gcc::compile_library("libhoedown.a", LIBHOEDOWN_SRC);
 }
-

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -561,6 +561,7 @@ impl<'a, R> Render for &'a mut R where R: Render {
 pub mod list {
     bitflags! {
         #[doc="Flags that describe a list or list item"]
+        #[repr(C)]
         flags List: u32 {
             #[doc="An ordered list or list item"]
             const ORDERED = 1 << 0,
@@ -573,6 +574,7 @@ pub mod list {
 
 /// The table alignment or position
 #[derive(Debug, Copy, Clone)]
+#[repr(C)]
 pub enum Table {
     Left = 1,
     Right,
@@ -583,6 +585,7 @@ pub enum Table {
 
 /// The type of an autolink candidate
 #[derive(Debug, Copy, Clone)]
+#[repr(C)]
 pub enum AutoLink {
     Normal = 1,
     Email,


### PR DESCRIPTION
This removes the crate's dependency on the libhoedown Makefile, by baking the necessary logic into the build script itself.  The major upside to this is that it makes compiling the crate on Windows much simpler.

An unrelated fix is to add `#[repr(C)]` to some additional types that were causing warnings in the FFI binding.