### PR TITLE
Fix compilation bug with recent bitflag versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "hoedown"
-version = "3.0.3"
+version = "3.0.4"
 authors = ["Jorge Israel Peña <jorge.israel.p@gmail.com>"]
 description = "bindings for the Hoedown markdown processor"
 repository = "https://github.com/blaenk/hoedown"
@@ -10,11 +10,11 @@ keywords = ["markdown"]
 build = "build.rs"
 
 [dependencies]
-bitflags = "*"
-libc = "*"
+bitflags = "0.5"
+libc = "0.2"
 
 [dev-dependencies]
-glob = "*"
+glob = "0.2"
 
 [build-dependencies]
 gcc = "0.3"

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,6 +1,6 @@
 bitflags! {
     #[doc="Constants for the various Hoedown extensions"]
-    flags Extension: u32 {
+    pub flags Extension: u32 {
         // block-level
 
         #[doc="Process table syntax"]

--- a/src/renderer/html.rs
+++ b/src/renderer/html.rs
@@ -30,7 +30,7 @@ pub fn smartypants(content: &Buffer, output: &mut Buffer) {
 /// Flags to control the behavior of the html renderer
 bitflags! {
     #[doc="Information about a list item"]
-    flags Flags: u32 {
+    pub flags Flags: u32 {
         #[doc="Ignore raw html"]
         const SKIP_HTML = 1 << 0,
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -562,7 +562,7 @@ pub mod list {
     bitflags! {
         #[doc="Flags that describe a list or list item"]
         #[repr(C)]
-        flags List: u32 {
+        pub flags List: u32 {
             #[doc="An ordered list or list item"]
             const ORDERED = 1 << 0,
 


### PR DESCRIPTION
Hoedown and crates depending on it (e.g. `cargo-extras`) are no longer compiling due to an issue with bitflags.
This PR fixes the issues and adds versioning in Crates.toml to hopefully avoid this problem in the future.

(tested with rust 1.7)